### PR TITLE
Move first BuildRequestReceived from FE to Kudu

### DIFF
--- a/Kudu.Contracts/Deployment/IDeploymentManager.cs
+++ b/Kudu.Contracts/Deployment/IDeploymentManager.cs
@@ -11,7 +11,7 @@ namespace Kudu.Core.Deployment
         DeployResult GetResult(string id);
         IEnumerable<LogEntry> GetLogEntries(string id);
         IEnumerable<LogEntry> GetLogEntryDetails(string id, string logId);
-        Task SendDeployStatusUpdate(DeployStatusApiResult updateStatusObj);
+        Task<bool> SendDeployStatusUpdate(DeployStatusApiResult updateStatusObj);
 
         void Delete(string id);
         Task DeployAsync(IRepository repository, ChangeSet changeSet, string deployer, bool clean, DeploymentInfoBase deploymentInfo = null, bool needFileUpdate = true, bool fullBuildByDefault = true);


### PR DESCRIPTION
Kudu will be responsible to put in the first request. This was previously happening in FE which will be removed.