### PR TITLE
Full proof check if we need to fallback to next restart method throug…

### DIFF
--- a/Kudu.Core.Test/Deployment/FetchDeploymentManagerFacts.cs
+++ b/Kudu.Core.Test/Deployment/FetchDeploymentManagerFacts.cs
@@ -207,6 +207,11 @@ namespace Kudu.Core.Test
                 return Task.FromResult(1);
             }
 
+            Task<bool> IDeploymentManager.SendDeployStatusUpdate(DeployStatusApiResult updateStatusObj)
+            {
+                throw new NotImplementedException();
+            }
+
             public class NoopDisposable : IDisposable
             {
                 public void Dispose()


### PR DESCRIPTION
The status returned by FE is getting converted to 200 (Similar to issues we saw for the throttling). This is a full proof check to make sure we fallback to the next restart method incase the HostingConfig is turned off.